### PR TITLE
Alter puppet-archive requirement to accept versions >1.3.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppet/archive",
-      "version_requirement": "1.3.x"
+      "version_requirement": ">= 1.3.0 <3.2.0"
     },
     {
       "name": "puppetlabs-inifile",


### PR DESCRIPTION
This has been tested and found to be working without issue. Left as restrictive as it is, I've found that this module doesn't play well with other modules that have moved beyond 1.3.x of puppet/archive.