### PR TITLE
Seperated package installation & proxy configuration #6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Seperated package installation & proxy configuration #6
 
 ## 0.9.4 - 2019-05-19
 ### Fixed

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,48 +70,11 @@ class amazon_ssm_agent (
       source   => "/tmp/amazon-ssm-agent.${pkg_format}",
     }
 
-    $proxy_env_vars = [ 'http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY' ]
-
-    case $srv_provider {
-      'upstart': {
-        $config_file = '/etc/init/amazon-ssm-agent.conf'
-        fail("Module support for ${srv_provider} service provider has been temporarily disabled")
-      }
-      'systemd': {
-        $config_file = '/etc/systemd/system/amazon-ssm-agent.service'
-        if $proxy_url {
-          $status = present
-        } else {
-          $status = absent
-        }
-        # Since puppetlabs/inifile module doesn't support repeat setting,
-        # we have to trick it into thinking that the setting includes the env var.
-        # Once puppetlabs/inifile supports repeat setting, it can be reverted back
-        # to 'Environment'
-        $proxy_env_vars.each |Integer $index, String $proxy_env_var| {
-          ini_setting { "Set proxy configuration ${proxy_env_var} with status ${status}":
-            ensure            => $status,
-            path              => $config_file,
-            section           => 'Service',
-            setting           => "Environment=\"${proxy_env_var}",
-            value             => "${proxy_url}\"",
-            key_val_separator => '=',
-            before            => Service['amazon-ssm-agent'],
-          }
-        }
-        ini_setting { "Set no_proxy configuration with status ${status}":
-          ensure            => $status,
-          path              => $config_file,
-          section           => 'Service',
-          setting           => "Environment=\"no_proxy",
-          value             => "169.254.169.254\"",
-          key_val_separator => '=',
-          before            => Service['amazon-ssm-agent'],
-        }
-      }
-      default: {
-        fail("Module does not support ${srv_provider} service provider")
-      }
+    class { '::amazon_ssm_agent::proxy':
+      proxy_url    => $proxy_url,
+      srv_provider => $srv_provider,
+      require      => Package['amazon-ssm-agent'],
+      before       => Service['amazon-ssm-agent'],
     }
 
     service { 'amazon-ssm-agent':

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -1,0 +1,90 @@
+# Class: amazon_ssm_agent
+# ===========================
+#
+# Configure amazon-ssm-agent proxy settings
+#
+# Parameters
+# ----------
+##
+# * `proxy_url`
+# Data Type: String
+# The proxy URL in <protocol>://<host>:<port> format, specify if the ssm agent needs to communicate via a proxy
+# Default value: undef
+#
+# * `srv_provider`
+# Data Type: srv_provider
+# The name of the service provider
+#
+#
+# Examples
+# --------
+# @example
+#    class { '::amazon_ssm_agent::proxy':
+#      proxy_url    => 'http://someproxy:3128',
+#      srv_provider => 'systemd'
+#    }
+#
+# Authors
+# -------
+#
+# Andy Wang <andy.wang@shinesolutions.com>
+#
+# Copyright
+# ---------
+#
+# Copyright 2017-2019 Shine Solutions, unless otherwise noted.
+#
+class amazon_ssm_agent::proxy (
+  $proxy_url    = undef,
+  $srv_provider = lookup('amazon_ssm_agent::srv_provider', String, 'first'),
+  ) {
+    $proxy_env_vars = [ 'http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY' ]
+
+    case $srv_provider {
+      'upstart': {
+        $config_file = '/etc/init/amazon-ssm-agent.conf'
+        fail("Module support for ${srv_provider} service provider has been temporarily disabled")
+      }
+      'systemd': {
+        $config_file = '/etc/systemd/system/amazon-ssm-agent.service'
+        if $proxy_url {
+          $status = present
+        } else {
+          $status = absent
+        }
+        # Since puppetlabs/inifile module doesn't support repeat setting,
+        # we have to trick it into thinking that the setting includes the env var.
+        # Once puppetlabs/inifile supports repeat setting, it can be reverted back
+        # to 'Environment'
+        $proxy_env_vars.each |Integer $index, String $proxy_env_var| {
+          ini_setting { "Set proxy configuration ${proxy_env_var} with status ${status}":
+            ensure            => $status,
+            path              => $config_file,
+            section           => 'Service',
+            setting           => "Environment=\"${proxy_env_var}",
+            value             => "${proxy_url}\"",
+            key_val_separator => '=',
+            before            => Service['amazon-ssm-agent'],
+            notify            => Exec['/usr/bin/systemctl daemon-reload'],
+          }
+        }
+        ini_setting { "Set no_proxy configuration with status ${status}":
+          ensure            => $status,
+          path              => $config_file,
+          section           => 'Service',
+          setting           => "Environment=\"no_proxy",
+          value             => "169.254.169.254\"",
+          key_val_separator => '=',
+          before            => Service['amazon-ssm-agent'],
+          notify            => Exec['/usr/bin/systemctl daemon-reload'],
+        }
+
+        exec { '/usr/bin/systemctl daemon-reload':
+          refreshonly => true,
+        }
+      }
+      default: {
+        fail("Module does not support ${srv_provider} service provider")
+      }
+  }
+}


### PR DESCRIPTION
This pr seperates the proxy configuration from the installation manifest. With this change it is possible to only configure the amazon-ssm-agent while the old process of installation & proxy configuration is still working.