### PR TITLE
Removed systemd reload as it may interferes with other modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Add example for proxy manifest
+
+### Removed
+- Removed systemd reload as it may interferes with other modules
+
 ## 0.10.0 - 2019-08-20
 ### Changed
 - Seperated package installation & proxy configuration [#6]

--- a/examples/proxy.pp
+++ b/examples/proxy.pp
@@ -1,0 +1,14 @@
+# The baseline for module testing used by Puppet Labs is that each manifest
+# should have a corresponding test manifest that declares that class or defined
+# type.
+#
+# Tests are then run by using puppet apply --noop (to check for compilation
+# errors and view a log of events) or by fully applying the test in a virtual
+# environment (to compare the resulting system state to the desired state).
+#
+# Learn more about module testing here:
+# https://docs.puppet.com/guides/tests_smoke.html
+#
+class { '::amazon_ssm_agent::proxy':
+  proxy_url => http://localhost:3128,
+}

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -65,7 +65,6 @@ class amazon_ssm_agent::proxy (
             value             => "${proxy_url}\"",
             key_val_separator => '=',
             before            => Service['amazon-ssm-agent'],
-            notify            => Exec['/usr/bin/systemctl daemon-reload'],
           }
         }
         ini_setting { "Set no_proxy configuration with status ${status}":
@@ -76,11 +75,6 @@ class amazon_ssm_agent::proxy (
           value             => "169.254.169.254\"",
           key_val_separator => '=',
           before            => Service['amazon-ssm-agent'],
-          notify            => Exec['/usr/bin/systemctl daemon-reload'],
-        }
-
-        exec { '/usr/bin/systemctl daemon-reload':
-          refreshonly => true,
         }
       }
       default: {


### PR DESCRIPTION
This pr will remove the systemd reload which was introduced with release 0.10.0. The problem is that if another submodule has already declared the systemd reload the puppet execution will fail. 