### PR TITLE
Support for Amazon Linux 2 arm instances

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,6 +53,9 @@ class amazon_ssm_agent (
       'i386': {
         $architecture = '386'
       }
+      'aarch64','arm64': {
+        $architecture = 'arm64'
+      }
       default: {
         fail("Module not supported on ${facts['os']['architecture']} architecture")
       }


### PR DESCRIPTION
AWS has an arm instance type now and a compatible ssm package. This commit adds the architecture to the sanity check.

```
$ rpm -q amazon-ssm-agent
amazon-ssm-agent-2.3.842.0-1.aarch64
```