### PR TITLE
CentOS compatibility with correct os name fact

### DIFF
--- a/data/RedHat/CentOS-7.yaml
+++ b/data/RedHat/CentOS-7.yaml
@@ -1,0 +1,3 @@
+---
+
+amazon_ssm_agent::srv_provider: systemd


### PR DESCRIPTION
CentOS does not use RedHat as an os.name.
```
$ facter os.name os.family
os.family => RedHat
os.name => CentOS
```

Without this fix, the module attempts to use upstart on CentOS 7.
