### PR TITLE
Make service ensure/enable configurable

### DIFF
--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -77,6 +77,7 @@ class amazon_ssm_agent::proxy (
           before            => Service['amazon-ssm-agent'],
         }
       }
+      'none': {}
       default: {
         fail("Module does not support ${srv_provider} service provider")
       }


### PR DESCRIPTION
Running this in a Docker container doesn't need to have the service running. Allow service ensure/enable to be parameterized.